### PR TITLE
Make Latitude and Longitude signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ file. This change log follows the conventions of
 
 ## [Unreleased]
 
+### Changed
+
+- `latitude` and `longitude` in `DeviceInfoResult` are now signed integers to accomodate for incoming responses with negative numbers.
+
 ## [v0.2.0] - 2022-06-13
 
 ### Added

--- a/src/responses/device_info_result/generic_device.rs
+++ b/src/responses/device_info_result/generic_device.rs
@@ -28,8 +28,8 @@ pub struct GenericDeviceInfoResult {
     pub avatar: String,
     pub has_set_location_info: bool,
     pub region: Option<String>,
-    pub longitude: Option<u64>,
-    pub latitude: Option<u64>,
+    pub longitude: Option<i64>,
+    pub latitude: Option<i64>,
     pub time_diff: Option<i64>,
 }
 impl TapoResponseExt for GenericDeviceInfoResult {}

--- a/src/responses/device_info_result/l510.rs
+++ b/src/responses/device_info_result/l510.rs
@@ -31,8 +31,8 @@ pub struct L510DeviceInfoResult {
     pub avatar: String,
     pub has_set_location_info: bool,
     pub region: Option<String>,
-    pub longitude: Option<u64>,
-    pub latitude: Option<u64>,
+    pub longitude: Option<i64>,
+    pub latitude: Option<i64>,
     pub time_diff: Option<i64>,
     //
     // Unique to this device

--- a/src/responses/device_info_result/l530.rs
+++ b/src/responses/device_info_result/l530.rs
@@ -31,8 +31,8 @@ pub struct L530DeviceInfoResult {
     pub avatar: String,
     pub has_set_location_info: bool,
     pub region: Option<String>,
-    pub longitude: Option<u64>,
-    pub latitude: Option<u64>,
+    pub longitude: Option<i64>,
+    pub latitude: Option<i64>,
     pub time_diff: Option<i64>,
     //
     // Unique to this device

--- a/src/responses/device_info_result/plug.rs
+++ b/src/responses/device_info_result/plug.rs
@@ -31,8 +31,8 @@ pub struct PlugDeviceInfoResult {
     pub avatar: String,
     pub has_set_location_info: bool,
     pub region: Option<String>,
-    pub longitude: Option<u64>,
-    pub latitude: Option<u64>,
+    pub longitude: Option<i64>,
+    pub latitude: Option<i64>,
     pub time_diff: Option<i64>,
     //
     // Unique to this device


### PR DESCRIPTION
Hi!
I recently tried your lib out and getting the device info errored out for me because the longitude was a signed int (I changed the numbers a bit to not leak my location):

```

 2022-08-02T20:40:26.776Z INFO  tapo_l530                    > Device info: L530DeviceInfoResult { device_id: "xxx", type: "SMART.TAPOBULB", model: "L530 Series", hw_id: "xxxx", hw_ver: "1.0.0", fw_id: "xxxx", fw_ver: "1.2.2 Build 20220110 Rel. 72329", oem_id: "xxxxx", mac: "10-27-F5-xx-xx-xx", ip: "xxx.xxx.xx.250", ssid: "wifi", signal_level: 2, rssi: -55, specs: "EU", lang: "en_US", device_on: false, on_time: 0, overheated: false, nickname: "xxxx", avatar: "bulb", has_set_location_info: true, region: Some("Europe/xxxxxx"), longitude: Some(-81963), latitude: Some(322558), time_diff: Some(0), brightness: 30, dynamic_light_effect_enable: false, dynamic_light_effect_id: None, hue: None, saturation: None, color_temp: 2700, default_states: LastStates(L530StateWrapper { state: L530State { brightness: 30, hue: None, saturation: None, color_temp: 2700 } }) }
```
