### PR TITLE
Make API types serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive", "serde_derive"] }
 serde_json = "1.0"
 serde_with = "3.0"
 thiserror = "1.0"
-time = { version = "0.3", features = ["parsing"] }
+time = { version = "0.3", features = ["parsing", "formatting"] }
 uuid = { version = "1.3", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/src/responses/device_info_result/default_state.rs
+++ b/src/responses/device_info_result/default_state.rs
@@ -1,7 +1,7 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// The default state of a device to be used when internet connectivity is lost after a power cut.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DefaultState<T> {
     Custom(T),

--- a/src/responses/device_info_result/generic_device.rs
+++ b/src/responses/device_info_result/generic_device.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::responses::{decode_value, DeviceInfoResultExt, TapoResponseExt};
 
 /// Device info of [`crate::ApiClient<GenericDevice>`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenericDeviceInfoResult {
     pub device_id: String,
     pub r#type: String,

--- a/src/responses/device_info_result/l510.rs
+++ b/src/responses/device_info_result/l510.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::responses::{decode_value, DefaultState, DeviceInfoResultExt, TapoResponseExt};
 
 /// Device info of Tapo L150. Superset of [`crate::responses::GenericDeviceInfoResult`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L510DeviceInfoResult {
     //
     // Inherited from GenericDeviceInfoResult
@@ -62,13 +62,13 @@ impl DeviceInfoResultExt for L510DeviceInfoResult {
 }
 
 /// L510 State wrapper.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L510StateWrapper {
     pub state: L510State,
 }
 
 /// L510 State.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L510State {
     pub brightness: u8,
 }

--- a/src/responses/device_info_result/l530.rs
+++ b/src/responses/device_info_result/l530.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::responses::{decode_value, DefaultState, DeviceInfoResultExt, TapoResponseExt};
 
 /// Device info of Tapo L530. Superset of [`crate::responses::GenericDeviceInfoResult`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L530DeviceInfoResult {
     //
     // Inherited from GenericDeviceInfoResult
@@ -62,13 +62,13 @@ impl DeviceInfoResultExt for L530DeviceInfoResult {
 }
 
 /// L530 State wrapper.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L530StateWrapper {
     pub state: L530State,
 }
 
 /// L530 State.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L530State {
     pub brightness: u8,
     pub hue: Option<u16>,

--- a/src/responses/device_info_result/l930.rs
+++ b/src/responses/device_info_result/l930.rs
@@ -1,11 +1,11 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::requests::LightingEffect;
 use crate::responses::{decode_value, DefaultState, DeviceInfoResultExt, TapoResponseExt};
 
 /// Device info of Tapo L930. Superset of [`crate::responses::GenericDeviceInfoResult`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L930DeviceInfoResult {
     //
     // Inherited from GenericDeviceInfoResult
@@ -59,13 +59,13 @@ impl DeviceInfoResultExt for L930DeviceInfoResult {
 }
 
 /// L930 State wrapper.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L930StateWrapper {
     pub state: L930State,
 }
 
 /// L930 State.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L930State {
     pub brightness: Option<u8>,
     pub hue: Option<u16>,

--- a/src/responses/device_info_result/plug.rs
+++ b/src/responses/device_info_result/plug.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 use crate::responses::{decode_value, DefaultState, DeviceInfoResultExt, TapoResponseExt};
 
 /// Device info of Tapo P100, P105, P110 and P115. Superset of [`crate::responses::GenericDeviceInfoResult`].
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlugDeviceInfoResult {
     //
     // Inherited from GenericDeviceInfoResult
@@ -55,13 +55,13 @@ impl DeviceInfoResultExt for PlugDeviceInfoResult {
 }
 
 /// Plug State wrapper.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlugStateWrapper {
     pub state: PlugState,
 }
 
 /// Plug State.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlugState {
     pub on: Option<bool>,
 }

--- a/src/responses/device_usage_result.rs
+++ b/src/responses/device_usage_result.rs
@@ -1,9 +1,9 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::responses::TapoResponseExt;
 
 /// Contains the time in use, the power consumption, and the energy savings of the device.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DeviceUsageResult {
     // Time usage in minutes
     pub time_usage: UsageByPeriodResult,
@@ -15,7 +15,7 @@ pub struct DeviceUsageResult {
 impl TapoResponseExt for DeviceUsageResult {}
 
 /// Usage by period result for today, the past 7 days, and the past 30 days.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct UsageByPeriodResult {
     /// Today
     pub today: u64,

--- a/src/responses/energy_data_result.rs
+++ b/src/responses/energy_data_result.rs
@@ -1,11 +1,11 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::responses::TapoResponseExt;
 use crate::tapo_date_format;
 
 /// Energy data for the requested [`crate::requests::EnergyDataInterval`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EnergyDataResult {
     /// Local time, with the UTC offset assumed from the machine this call is made on
     #[serde(with = "tapo_date_format")]

--- a/src/responses/energy_usage_result.rs
+++ b/src/responses/energy_usage_result.rs
@@ -1,11 +1,11 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::responses::TapoResponseExt;
 use crate::tapo_date_format;
 
 /// Contains local time, current power and the energy usage and runtime for today and for the current month.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EnergyUsageResult {
     /// Local time, with the UTC offset assumed from the machine this call is made on
     #[serde(with = "tapo_date_format")]

--- a/src/responses/handshake_result.rs
+++ b/src/responses/handshake_result.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::TapoResponseExt;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct HandshakeResult {
     pub key: String,
 }

--- a/src/responses/tapo_response.rs
+++ b/src/responses/tapo_response.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, TapoResponseError};
 
@@ -7,7 +7,7 @@ pub(crate) trait TapoResponseExt {}
 
 impl TapoResponseExt for serde_json::Value {}
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TapoResponse<T: TapoResponseExt> {
     pub error_code: i32,
     pub result: Option<T>,

--- a/src/responses/tapo_result.rs
+++ b/src/responses/tapo_result.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::responses::TapoResponseExt;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TapoResult {
     pub response: String,
 }

--- a/src/responses/token_result.rs
+++ b/src/responses/token_result.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::responses::TapoResponseExt;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TokenResult {
     pub token: String,
 }

--- a/src/tapo_date_format.rs
+++ b/src/tapo_date_format.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serializer};
 use time::{format_description, OffsetDateTime, PrimitiveDateTime};
 
 const FORMAT: &str = "[year]-[month]-[day] [hour]:[minute]:[second]";
@@ -18,4 +18,15 @@ where
     let offset = OffsetDateTime::now_utc().offset();
 
     Ok(primitive.assume_offset(offset))
+}
+
+pub fn serialize<S>(data: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let format = format_description::parse(FORMAT).map_err(serde::ser::Error::custom)?;
+
+    let formatted = data.format(&format).map_err(serde::ser::Error::custom)?;
+
+    serializer.serialize_str(&formatted)
 }


### PR DESCRIPTION
Following discussions in #56, this PR makes API types serializable so that they can be exposed through a REST API server (or GraphQL, gRPC, etc.).

Ping @mihai-dinculescu 