### PR TITLE
Make the ApiClientExt trait thread-safe

### DIFF
--- a/src/api/api_client.rs
+++ b/src/api/api_client.rs
@@ -30,7 +30,7 @@ pub struct Unauthenticated;
 pub struct Authenticated;
 
 #[async_trait]
-pub(crate) trait ApiClientExt: std::fmt::Debug {
+pub(crate) trait ApiClientExt: std::fmt::Debug + Send + Sync {
     async fn set_device_info(&self, device_info_params: serde_json::Value) -> Result<(), Error>;
 }
 


### PR DESCRIPTION
Allows a `dyn ApiClientExt` to be sent between threads. Useless for methods like `.on()` or `.off()` but required for some others like `.set_brightness()`

Related to #56