### PR TITLE
Handle errors in passthrough test correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,20 @@ file. This change log follows the conventions of
 - The internal implementation of `H100Handler`'s `get_child_device_list` has been updated to fetch all pages, not just the first one.
 - `H100Handler`'s `get_child_device_list_json` now includes a `start_index` parameter to fetch child devices starting from a specific index.
 
+#### Fixed
+
+- Resolved an issue that caused the passthrough protocol test to incorrectly indicate support when it was not actually supported. (thanks to @WhySoBad)
+
 ### Python
 
 #### Changed
 
 - The internal implementation of `H100Handler`'s `get_child_device_list` has been updated to fetch all pages, not just the first one.
 - `H100Handler`'s `get_child_device_list_json` now includes a `start_index` parameter to fetch child devices starting from a specific index.
+
+#### Fixed
+
+- Resolved an issue that caused the passthrough protocol test to incorrectly indicate support when it was not actually supported. (thanks to @WhySoBad)
 
 ## [v0.8.0][v0.8.0] - 2024-12-07
 

--- a/tapo/src/api/protocol/discovery_protocol.rs
+++ b/tapo/src/api/protocol/discovery_protocol.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::{debug, warn};
 use reqwest::Client;
 
 use crate::api::protocol::klap_protocol::KlapProtocol;
@@ -37,10 +37,10 @@ impl DiscoveryProtocol {
         match self.test_passthrough(url).await {
             Err(Error::Tapo(TapoResponseError::Unknown(code))) => Ok(code != 1003),
             Err(err) => {
-                debug!("Error during passthrough test: {err:?}");
-                 Err(err)
-            },
-            Ok(_) => Ok(true)
+                warn!("Passthrough protocol test error: {err:?}");
+                Err(err)
+            }
+            Ok(_) => Ok(true),
         }
     }
 

--- a/tapo/src/api/protocol/discovery_protocol.rs
+++ b/tapo/src/api/protocol/discovery_protocol.rs
@@ -34,14 +34,14 @@ impl DiscoveryProtocol {
     }
 
     async fn is_passthrough_supported(&self, url: &str) -> Result<bool, Error> {
-        if let Err(Error::Tapo(TapoResponseError::Unknown(code))) = self.test_passthrough(url).await
-        {
-            if code == 1003 {
-                return Ok(false);
-            }
+        match self.test_passthrough(url).await {
+            Err(Error::Tapo(TapoResponseError::Unknown(code))) => Ok(code != 1003),
+            Err(err) => {
+                debug!("Error during passthrough test: {err:?}");
+                 Err(err)
+            },
+            Ok(_) => Ok(true)
         }
-
-        Ok(true)
     }
 
     async fn test_passthrough(&self, url: &str) -> Result<(), Error> {


### PR DESCRIPTION
Hi,

Whilst experimenting with your library, I experienced a case where my lamp wasn't reachable over the network but the library printed that the passthrough protocol is supported.

The reason for this false assumption is the incorrect error handling of the `test_passthrough` method. Currently, it's only checked whether the error case of the result is a tapo error but any other errors are ignored and handled as if the request succeeded. 
