### PR TITLE
Add session initialization hook for remote environments

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install gh CLI if not already installed
+if ! command -v gh &>/dev/null; then
+  (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat "$out" | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install gh -y
+fi
+
+# Authenticate gh using GITHUB_TOKEN if available
+if [ -n "${GITHUB_TOKEN:-}" ] && ! gh auth status &>/dev/null; then
+  echo "$GITHUB_TOKEN" | gh auth login --with-token
+fi
+
+# Install cargo-make if not already installed
+if ! command -v cargo-make &>/dev/null && ! cargo make --version &>/dev/null 2>&1; then
+  cargo install cargo-make
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Summary
This PR adds a session initialization hook that automatically sets up required tools and authentication in remote (web) Claude environments.

## Key Changes
- **New hook script** (`.claude/hooks/session-start.sh`): Automatically installs and configures essential tools when a session starts in a remote environment
  - Installs GitHub CLI (`gh`) if not present, including GPG key setup for package verification
  - Authenticates `gh` using the `GITHUB_TOKEN` environment variable when available
  - Installs `cargo-make` if not already available
  - Only runs in remote environments (checks `CLAUDE_CODE_REMOTE` flag)

- **Updated settings** (`.claude/settings.json`): Registers the new session start hook to execute the initialization script

## Implementation Details
- The hook uses defensive checks (`command -v`, `cargo make --version`) to avoid reinstalling tools that are already present
- GitHub CLI installation follows the official installation method with proper GPG key verification
- The script exits gracefully (exit 0) when not in a remote environment to avoid errors in local setups
- Uses strict bash settings (`set -euo pipefail`) for reliability

https://claude.ai/code/session_01Sieh7vbp9nHYxHWgPwVJwP