### PR TITLE
ci(tapo-py): add path filtering to pull_request trigger

### DIFF
--- a/.github/workflows/tapo-py.yml
+++ b/.github/workflows/tapo-py.yml
@@ -12,6 +12,12 @@ on:
     tags:
       - "v*"
   pull_request:
+    paths:
+      - "tapo/**"
+      - "tapo-py/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/tapo-py.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add path filtering to the `pull_request` trigger so the Python wheel build only runs on PRs that touch `tapo/`, `tapo-py/`, `Cargo.lock`, `Cargo.toml`, or the workflow file itself.