### PR TITLE
ci(tapo-mcp): use native ARM runner and pin to ubuntu-24.04

### DIFF
--- a/.github/workflows/tapo-mcp.yml
+++ b/.github/workflows/tapo-mcp.yml
@@ -24,18 +24,17 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64/v8
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64/v8
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,6 +65,12 @@ jobs:
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
+      - name: Prepare platform pair
+        if: github.event_name != 'pull_request'
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Export digest
         if: github.event_name != 'pull_request'
         run: |
@@ -77,14 +82,14 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ hashFiles('/tmp/digests/*') }}
+          name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
   merge:
     name: Merge manifests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request'
     needs: build
     steps:


### PR DESCRIPTION
## Summary
- Use native `ubuntu-24.04-arm` runner for `linux/arm64/v8` builds instead of QEMU emulation, significantly improving build speed
- Pin all runners to `ubuntu-24.04` instead of `ubuntu-latest` for reproducibility
- Fix artifact name collision bug: `hashFiles` on empty `touch`-created digest files produces identical hashes across matrix legs, replaced with platform-derived names (`digests-linux-amd64`, `digests-linux-arm64-v8`)
- Remove now-unnecessary QEMU setup step

## Test plan
- [ ] Verify workflow runs successfully on push to main
- [ ] Verify both amd64 and arm64 images are built and pushed
- [ ] Verify manifest list is correctly created with both architectures

https://claude.ai/code/session_01VpqUt55oEk3u8FtyL7aAE7