### PR TITLE
docs: add tapoviz to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ An MCP server that exposes Tapo devices as AI-callable tools and resources via t
 ## Community Projects
 
 - [tapo-rest][tapo_rest] — a REST wrapper of this library that can be deployed as a service or serve as an advanced example.
+- [tapoviz][tapoviz] — audio-reactive and screen-reactive lighting for L920/L930 LED strips, with a local web UI.
 
 ## Troubleshooting
 
@@ -117,6 +118,7 @@ Inspired by [petretiandrea/plugp100][inspired_by].
 [examples-py]: https://github.com/mihai-dinculescu/tapo/tree/main/tapo-py/examples
 [tapo_mcp]: https://github.com/mihai-dinculescu/tapo/tree/main/tapo-mcp
 [tapo_rest]: https://github.com/ClementNerma/tapo-rest
+[tapoviz]: https://github.com/The-DarkMatter/tapoviz
 [troubleshooting]: https://github.com/mihai-dinculescu/tapo/blob/main/TROUBLESHOOTING.md
 [contributing]: https://github.com/mihai-dinculescu/tapo/blob/main/CONTRIBUTING.md
 [inspired_by]: https://github.com/petretiandrea/plugp100


### PR DESCRIPTION
Add tapoviz to Community Projects

Hi @mihai-dinculescu, first off, thanks for this library. It made building this a lot easier than dealing with the Tapo protocol directly.

I built [tapoviz](https://github.com/The-DarkMatter/tapoviz) on top of tapo: audio-reactive and screen-reactive (ambilight) lighting for L920/L930 strips, plus an OpenRGB bridge over sACN, a local web UI, and support for both plain strips and strips wrapped around something like a monitor.

Opening this in case you'd like it listed alongside tapo-rest, happy to adjust the wording or drop it if you'd rather not, no worries either way.